### PR TITLE
Change default button class to btn-primary

### DIFF
--- a/bootstrap4/forms.py
+++ b/bootstrap4/forms.py
@@ -86,7 +86,7 @@ def render_label(content, label_for=None, label_class=None, label_title=""):
 def render_button(
     content,
     button_type=None,
-    button_class="btn-default",
+    button_class="btn-primary",
     size="",
     href="",
     name=None,


### PR DESCRIPTION
Bootstrap 4 doesn't have a btn-default class.